### PR TITLE
Substitute native keccak with Merkle commitment on data integrity hash

### DIFF
--- a/contracts/BinaryRelated.sol
+++ b/contracts/BinaryRelated.sol
@@ -21,16 +21,4 @@ library BinaryRelated {
         return n << 1;
     }
 
-    function getExponentiation(uint256 n) internal pure returns (uint256) {
-        uint256 cnt = 0;
-        while(n != 0) {
-            n = n >> 1;
-            cnt++;
-        }
-        return cnt-1;
-    }
-
-    function getBitsLen(uint256 n) internal pure returns (uint256) {
-        return (n <= 1) ? 0 : BinaryRelated.getExponentiation(BinaryRelated.findNextPowerOf2(n));
-    }
 }

--- a/contracts/BinaryRelated.sol
+++ b/contracts/BinaryRelated.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+library BinaryRelated {
+    function pow(uint256 fp, uint256 n) internal pure returns (uint256) {
+        // 1.0 in Q128.128
+        uint256 v = 1 << 128;
+        while (n != 0) {
+            if ((n & 1) == 1) {
+                v = (v * fp) >> 128;
+            }
+            fp = (fp * fp) >> 128;
+            n = n / 2;
+        }
+        return v;
+    }
+
+    function findNextPowerOf2(uint256 n) internal pure returns (uint256) {
+        n = n-1;
+        while ((n & (n-1) != 0)) n = n & (n-1);
+        return n << 1;
+    }
+
+    function getExponentiation(uint256 n) internal pure returns (uint256) {
+        uint256 cnt = 0;
+        while(n != 0) {
+            n = n >> 1;
+            cnt++;
+        }
+        return cnt-1;
+    }
+
+    function getBitsLen(uint256 n) internal pure returns (uint256) {
+        return (n <= 1) ? 0 : BinaryRelated.getExponentiation(BinaryRelated.findNextPowerOf2(n));
+    }
+}

--- a/contracts/DKVDaggerHashimoto.sol
+++ b/contracts/DKVDaggerHashimoto.sol
@@ -211,7 +211,7 @@ contract DecentralizedKVDaggerHashimoto is DecentralizedKV {
     ) internal view returns (bytes32) {
         /* Assumption check */
         require(maskedData.length == randomChecks, "data vs checks: length mismatch");
-        require(maskedData[0].length <= chunkSize, "too large data uploaded");
+        require(maskedData[0].length == chunkSize, "too large data uploaded");
 
         uint256 maxKvSize = 1 << maxKvSizeBits;
         uint256 rows = 1 << (shardEntryBits + shardLenBits);
@@ -249,7 +249,7 @@ contract DecentralizedKVDaggerHashimoto is DecentralizedKV {
         uint256 rows = 1 << (shardEntryBits + shardLenBits + chunkLenBits);
 
         for (uint256 i = 0; i < randomChecks; i++) {
-            require(maskedData[i].length <= chunkSize, "invalid proof size");
+            require(maskedData[i].length == chunkSize, "invalid proof size");
             uint256 parent = uint256(hash0) % rows;
             uint256 chunkIdx = parent + (startShardId << (shardEntryBits + chunkLenBits));
             uint256 kvIdx = chunkIdx >> chunkLenBits;

--- a/contracts/DKVDaggerHashimoto.sol
+++ b/contracts/DKVDaggerHashimoto.sol
@@ -379,7 +379,6 @@ contract DecentralizedKVDaggerHashimoto is DecentralizedKV {
         address miner,
         uint256 minedTs,
         uint256 nonce,
-        uint256[] memory checkIdList,
         bytes32[][] memory proofsDim2,
         bytes[] memory maskedData
     ) public virtual {

--- a/contracts/DKVDaggerHashimoto.sol
+++ b/contracts/DKVDaggerHashimoto.sol
@@ -10,6 +10,7 @@ import "./MiningLib.sol";
 contract DecentralizedKVDaggerHashimoto is DecentralizedKV {
     struct Config {
         uint256 maxKvSizeBits;
+        uint256 chunkSizeBits;
         uint256 shardSizeBits;
         uint256 randomChecks;
         uint256 minimumDiff;
@@ -42,18 +43,19 @@ contract DecentralizedKVDaggerHashimoto is DecentralizedKV {
         bytes32 _genesisHash
     )
         payable
-        DecentralizedKV(_config.systemContract, 1 << _config.maxKvSizeBits, _startTime, _storageCost, _dcfFactor)
+        DecentralizedKV(_config.systemContract, 1 << _config.maxKvSizeBits, 1 << _config.chunkSizeBits,
+                        _startTime, _storageCost, _dcfFactor)
     {
         /* Assumptions */
         require(_config.shardSizeBits >= _config.maxKvSizeBits, "shardSize too small");
+        require(_config.maxKvSizeBits >= _config.chunkSizeBits, "maxKvSize too small");
         require(_config.randomChecks > 0, "At least one checkpoint needed");
 
         systemContract = _config.systemContract;
         shardSizeBits = _config.shardSizeBits;
         maxKvSizeBits = _config.maxKvSizeBits;
         shardEntryBits = _config.shardSizeBits - _config.maxKvSizeBits;
-        chunkLenBits = _config.maxKvSizeBits < DEFAULT_CHUNK_SIZE_BITS ?
-                       0 : _config.maxKvSizeBits - DEFAULT_CHUNK_SIZE_BITS;
+        chunkLenBits = _config.maxKvSizeBits - _config.chunkSizeBits;
         randomChecks = _config.randomChecks;
         minimumDiff = _config.minimumDiff;
         targetIntervalSec = _config.targetIntervalSec;

--- a/contracts/DKVDaggerHashimoto.sol
+++ b/contracts/DKVDaggerHashimoto.sol
@@ -265,14 +265,16 @@ contract DecentralizedKVDaggerHashimoto is DecentralizedKV {
     ) internal view returns (bytes32) {
         require(maskedData.length == randomChecks, "data vs checks: length mismatch");
         require(proofsDim2.length == randomChecks, "proofs vs checks: length mismatch");
-        require(maskedData.length <= CHUNK_SIZE, "calldata too large");
+        require(maskedData.length == randomChecks, "data vs checks: length mismatch");
         uint256 maxKvSize = 1 << maxKvSizeBits;
 
         for (uint256 i = 0; i < randomChecks; i++) {
-            require(maskedData[i].length == maxKvSize, "invalid proof size");
+            require(maskedData[i].length <= CHUNK_SIZE, "invalid proof size");
             uint256 kvIdx = _generateKVIdx(hash0, startShardId, shardLenBits);
             uint256 chunkIdx = _generateChunkIdx(hash0);
             bytes memory data = maskedData[i];
+            /* NOTICE: Now we have kvIdx and chunkIdx both generated from hash0
+             *         The difficulty should increase intrinsically */
             require(systemContract.checkDaggerDataWithProof(chunkIdx, 
                     kvMap[idxMap[kvIdx]].hash, proofsDim2[i], data),
                     "invalid access proof");

--- a/contracts/DecentralizedKV.sol
+++ b/contracts/DecentralizedKV.sol
@@ -104,8 +104,7 @@ contract DecentralizedKV {
             lastKvIdx = lastKvIdx + 1;
         }
         paddr.kvSize = uint24(data.length);
-        uint256 nChunkBits = generateChunkBits(data.length);
-        paddr.hash = bytes24(MerkleLib.merkleRoot(data, chunkSize, nChunkBits));
+        paddr.hash = bytes24(MerkleLib.merkleRootWithMinTree(data, chunkSize));
         kvMap[skey] = paddr;
 
         // Weird that cannot call precompiled contract like this (solidity issue?)
@@ -200,8 +199,7 @@ contract DecentralizedKV {
             return false;
         }
 
-        uint256 nChunkBits = generateChunkBits(data.length);
-        bytes24 dataHash = bytes24(MerkleLib.merkleRoot(data, chunkSize, nChunkBits));
+        bytes24 dataHash = bytes24(MerkleLib.merkleRootWithMinTree(data, chunkSize));
         return paddr.hash == dataHash;
     }
 }

--- a/contracts/DecentralizedKV.sol
+++ b/contracts/DecentralizedKV.sol
@@ -35,6 +35,7 @@ contract DecentralizedKV {
     constructor(
         IStorageManager _storageManager,
         uint256 _maxKvSize,
+        uint256 _chunkSize,
         uint256 _startTime,
         uint256 _storageCost,
         uint256 _dcfFactor
@@ -44,7 +45,9 @@ contract DecentralizedKV {
         maxKvSize = _maxKvSize;
         storageCost = _storageCost;
         dcfFactor = _dcfFactor;
-        chunkSize = _maxKvSize < (1 << DEFAULT_CHUNK_SIZE_BITS) ? _maxKvSize : (1 << DEFAULT_CHUNK_SIZE_BITS);
+        chunkSize = _chunkSize;
+        require(_chunkSize <= _maxKvSize, "KV: size mismatch");
+        require((_chunkSize != 0) && ((_chunkSize & (_chunkSize - 1)) == 0), "chunkSize aligned with 2^n");
     }
 
     function pow(uint256 fp, uint256 n) internal pure returns (uint256) {

--- a/contracts/DecentralizedKV.sol
+++ b/contracts/DecentralizedKV.sol
@@ -14,7 +14,6 @@ contract DecentralizedKV {
     uint256 public immutable maxKvSize;
     uint256 public immutable chunkSize;
     uint40 public lastKvIdx = 0; // number of entries in the store
-    uint256 public constant DEFAULT_CHUNK_SIZE_BITS = 12; // 4K bytes is normal SSD minimal fetchable size
 
     IStorageManager public immutable storageManager;
 

--- a/contracts/DecentralizedKV.sol
+++ b/contracts/DecentralizedKV.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 import "./IStorageManager.sol";
 import "./MerkleLib.sol";
+import "./BinaryRelated.sol";
 
 contract DecentralizedKV {
     uint256 public immutable storageCost; // Upfront storage cost (pre-dcf)
@@ -48,11 +49,6 @@ contract DecentralizedKV {
 
     function pow(uint256 fp, uint256 n) internal pure returns (uint256) {
         return BinaryRelated.pow(fp, n);
-    }
-
-    function generateChunkBits(uint256 dataLen) internal view returns (uint256) {
-        uint256 n = dataLen / chunkSize;
-        return BinaryRelated.getBitsLen(n);
     }
 
     // Evaluate payment from [t0, t1) seconds

--- a/contracts/DecentralizedKVMinable.sol
+++ b/contracts/DecentralizedKVMinable.sol
@@ -7,6 +7,7 @@ import "./MiningLib.sol";
 contract DecentralizedKVMinable is DecentralizedKV {
     struct Config {
         uint256 maxKvSizeBits;
+        uint256 chunkSizeBits;
         uint256 shardSizeBits;
         uint256 randomChecks;
         uint256 minimumDiff;
@@ -38,8 +39,11 @@ contract DecentralizedKVMinable is DecentralizedKV {
         bytes32 _genesisHash
     )
         payable
-        DecentralizedKV(_config.systemContract, 1 << _config.maxKvSizeBits, _startTime, _storageCost, _dcfFactor)
+        DecentralizedKV(_config.systemContract, 1 << _config.maxKvSizeBits, 1 << _config.chunkSizeBits,
+                         _startTime, _storageCost, _dcfFactor)
     {
+        require(_config.shardSizeBits >= _config.maxKvSizeBits, "config size mismatch");
+        require(_config.randomChecks > 0, "randomChecks must be nonzero");
         systemContract = _config.systemContract;
         shardSizeBits = _config.shardSizeBits;
         maxKvSizeBits = _config.maxKvSizeBits;

--- a/contracts/DecentralizedKVMinable.sol
+++ b/contracts/DecentralizedKVMinable.sol
@@ -169,7 +169,7 @@ contract DecentralizedKVMinable is DecentralizedKV {
             } else {
                 bytes32 skey = idxMap[kvIdx];
                 // Expect the provided masked data equals to local hash
-                if (bytes24(dataHashes[i]) == kvMap[skey].hash) {
+                if (dataHashes[i] == kvMap[skey].hash) {
                     matched = matched + 1;
                 }
             }

--- a/contracts/DecentralizedKVMinable.sol
+++ b/contracts/DecentralizedKVMinable.sol
@@ -169,7 +169,7 @@ contract DecentralizedKVMinable is DecentralizedKV {
             } else {
                 bytes32 skey = idxMap[kvIdx];
                 // Expect the provided masked data equals to local hash
-                if (dataHashes[i] == kvMap[skey].hash) {
+                if (bytes24(dataHashes[i]) == kvMap[skey].hash) {
                     matched = matched + 1;
                 }
             }

--- a/contracts/IStorageManager.sol
+++ b/contracts/IStorageManager.sol
@@ -39,8 +39,45 @@ interface IDaggerHash {
         bytes32 kvHash,
         bytes memory maskedData
     ) external view returns (bool);
+
+    function checkDaggerDataWithProof(
+        uint256 kvIdx,
+        bytes32 kvHash,
+        bytes32[] memory proofs,
+        bytes memory maskedData
+    ) external view returns (bool);
 }
 
 interface ISystemContract is IStorageManager, IMiningHash {}
 
 interface ISystemContractDaggerHashimoto is IStorageManager, IDaggerHash {}
+
+library BinaryRelated {
+    function pow(uint256 fp, uint256 n) internal pure returns (uint256) {
+        // 1.0 in Q128.128
+        uint256 v = 1 << 128;
+        while (n != 0) {
+            if ((n & 1) == 1) {
+                v = (v * fp) >> 128;
+            }
+            fp = (fp * fp) >> 128;
+            n = n / 2;
+        }
+        return v;
+    }
+
+    function findNextPowerOf2(uint256 n) internal pure returns (uint256) {
+        n = n-1;
+        while ((n & (n-1) != 0)) n = n & (n-1);
+        return n << 1;
+    }
+
+    function getExponentiation(uint256 n) internal pure returns (uint256) {
+        uint256 cnt = 0;
+        while(n != 0) {
+            n = n >> 1;
+            cnt++;
+        }
+        return cnt-1;
+    }
+}

--- a/contracts/IStorageManager.sol
+++ b/contracts/IStorageManager.sol
@@ -52,36 +52,3 @@ interface ISystemContract is IStorageManager, IMiningHash {}
 
 interface ISystemContractDaggerHashimoto is IStorageManager, IDaggerHash {}
 
-library BinaryRelated {
-    function pow(uint256 fp, uint256 n) internal pure returns (uint256) {
-        // 1.0 in Q128.128
-        uint256 v = 1 << 128;
-        while (n != 0) {
-            if ((n & 1) == 1) {
-                v = (v * fp) >> 128;
-            }
-            fp = (fp * fp) >> 128;
-            n = n / 2;
-        }
-        return v;
-    }
-
-    function findNextPowerOf2(uint256 n) internal pure returns (uint256) {
-        n = n-1;
-        while ((n & (n-1) != 0)) n = n & (n-1);
-        return n << 1;
-    }
-
-    function getExponentiation(uint256 n) internal pure returns (uint256) {
-        uint256 cnt = 0;
-        while(n != 0) {
-            n = n >> 1;
-            cnt++;
-        }
-        return cnt-1;
-    }
-
-    function getBitsLen(uint256 n) internal pure returns (uint256) {
-        return (n <= 1) ? 0 : BinaryRelated.getExponentiation(BinaryRelated.findNextPowerOf2(n));
-    }
-}

--- a/contracts/IStorageManager.sol
+++ b/contracts/IStorageManager.sol
@@ -80,4 +80,8 @@ library BinaryRelated {
         }
         return cnt-1;
     }
+
+    function getBitsLen(uint256 n) internal pure returns (uint256) {
+        return (n <= 1) ? 0 : BinaryRelated.getExponentiation(BinaryRelated.findNextPowerOf2(n));
+    }
 }

--- a/contracts/MerkleLib.sol
+++ b/contracts/MerkleLib.sol
@@ -41,8 +41,8 @@ library MerkleLib {
         bytes memory data,
         uint256 chunkSize
     ) internal pure returns (bytes32) {
+        if (data.length == 0) return bytes32(0);
         uint256 nChunks = (data.length + chunkSize - 1) / chunkSize;
-        nChunks = nChunks < 1 ? 1 : nChunks;
         bytes32[] memory nodes = new bytes32[](nChunks);
         for (uint256 i = 0; i < nChunks; i++) {
             bytes32 hash;

--- a/contracts/MerkleLib.sol
+++ b/contracts/MerkleLib.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import "./BinaryRelated.sol";
+
 library MerkleLib {
     // Calculate the Merkle root of a given data with chunk size and number of maximum chunks in the data limit.
     function merkleRoot(
@@ -42,7 +44,8 @@ library MerkleLib {
         uint256 chunkSize
     ) internal pure returns (bytes32) {
         if (data.length == 0) return bytes32(0);
-        uint256 nChunks = (data.length + chunkSize - 1) / chunkSize;
+        uint256 n = (data.length + chunkSize - 1) / chunkSize;
+        uint256 nChunks = n <= 1 ? 1 : BinaryRelated.findNextPowerOf2(n);
         bytes32[] memory nodes = new bytes32[](nChunks);
         for (uint256 i = 0; i < nChunks; i++) {
             bytes32 hash;
@@ -60,7 +63,7 @@ library MerkleLib {
             }
             nodes[i] = hash;
         }
-        uint256 n = nChunks;
+        n = nChunks;
         while (n != 1) {
             for (uint256 i = 0; i < n / 2; i++) {
                 nodes[i] = keccak256(abi.encode(nodes[i * 2], nodes[i * 2 + 1]));

--- a/contracts/MerkleLib.sol
+++ b/contracts/MerkleLib.sol
@@ -46,7 +46,7 @@ library MerkleLib {
     ) internal pure returns (bool) {
         bytes32 hash = dataHash;
         uint256 nChunkBits = proofs.length;
-        if (chunkIdx >= (1 << nChunkBits)) return false;
+        require(chunkIdx < (1 << nChunkBits), "chunkId overflows");
         for (uint256 i = 0; i < nChunkBits; i++) {
             if (chunkIdx % 2 == 0) {
                 hash = keccak256(abi.encode(hash, proofs[i]));
@@ -55,7 +55,13 @@ library MerkleLib {
             }
             chunkIdx = chunkIdx / 2;
         }
-        return hash == root;
+        /* NOTICE: Due to our design of PhyAddr, only front 24 bytes
+         *         are valid. We only validate that part.
+         * With no doubt, it introduces some vulnerability compared 
+         * with a standard Merkle validation. It is a trade-off,
+         * if we want to put all meta data into a single bytes32(opcode length)
+         */
+        return bytes24(hash) == bytes24(root);
     }
 
     function getProof(

--- a/contracts/MerkleLib.sol
+++ b/contracts/MerkleLib.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import "./BinaryRelated.sol";
+
 library MerkleLib {
     // Calculate the Merkle root of a given data with chunk size and number of maximum chunks in the data limit.
     function merkleRoot(
@@ -37,6 +39,41 @@ library MerkleLib {
         return nodes[0];
     }
 
+    function merkleRootWithMinTree(
+        bytes memory data,
+        uint256 chunkSize
+    ) internal pure returns (bytes32) {
+        uint256 n = (data.length + chunkSize - 1) / chunkSize;
+        /* Round up to next 2^n */
+        uint256 nChunks = (n <= 1) ? 1 : BinaryRelated.findNextPowerOf2(n);
+        bytes32[] memory nodes = new bytes32[](nChunks);
+        for (uint256 i = 0; i < nChunks; i++) {
+            bytes32 hash;
+            uint256 off = i * chunkSize;
+            if (off >= data.length) {
+                // empty mean the leaf is zero
+                break;
+            }
+            uint256 len = data.length - off;
+            if (len >= chunkSize) {
+                len = chunkSize;
+            }
+            assembly {
+                hash := keccak256(add(add(data, 0x20), off), len)
+            }
+            nodes[i] = hash;
+        }
+        n = nChunks;
+        while (n != 1) {
+            for (uint256 i = 0; i < n / 2; i++) {
+                nodes[i] = keccak256(abi.encode(nodes[i * 2], nodes[i * 2 + 1]));
+            }
+
+            n = n / 2;
+        }
+        return nodes[0];
+    }
+
     // Verify the if the hash of a chunk data is in the chunks
     function verify(
         bytes32 dataHash,
@@ -55,13 +92,28 @@ library MerkleLib {
             }
             chunkIdx = chunkIdx / 2;
         }
-        /* NOTICE: Due to our design of PhyAddr, only front 24 bytes
-         *         are valid. We only validate that part.
-         * With no doubt, it introduces some vulnerability compared 
-         * with a standard Merkle validation. It is a trade-off,
-         * if we want to put all meta data into a single bytes32(opcode length)
-         */
-        return bytes24(hash) == bytes24(root);
+        
+        return hash == root;
+    }
+
+    function calculateRootWithProof(
+        bytes32 dataHash,
+        uint256 chunkIdx,
+        bytes32[] memory proofs
+    ) internal pure returns (bytes32) {
+        bytes32 hash = dataHash;
+        uint256 nChunkBits = proofs.length;
+        require(chunkIdx < (1 << nChunkBits), "chunkId overflows");
+        for (uint256 i = 0; i < nChunkBits; i++) {
+            if (chunkIdx % 2 == 0) {
+                hash = keccak256(abi.encode(hash, proofs[i]));
+            } else {
+                hash = keccak256(abi.encode(proofs[i], hash));
+            }
+            chunkIdx = chunkIdx / 2;
+        }
+
+        return hash;
     }
 
     function getProof(

--- a/contracts/MerkleLib.sol
+++ b/contracts/MerkleLib.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "./BinaryRelated.sol";
-
 library MerkleLib {
     // Calculate the Merkle root of a given data with chunk size and number of maximum chunks in the data limit.
     function merkleRoot(
@@ -43,9 +41,8 @@ library MerkleLib {
         bytes memory data,
         uint256 chunkSize
     ) internal pure returns (bytes32) {
-        uint256 n = (data.length + chunkSize - 1) / chunkSize;
-        /* Round up to next 2^n */
-        uint256 nChunks = (n <= 1) ? 1 : BinaryRelated.findNextPowerOf2(n);
+        uint256 nChunks = (data.length + chunkSize - 1) / chunkSize;
+        nChunks = nChunks < 1 ? 1 : nChunks;
         bytes32[] memory nodes = new bytes32[](nChunks);
         for (uint256 i = 0; i < nChunks; i++) {
             bytes32 hash;
@@ -63,7 +60,7 @@ library MerkleLib {
             }
             nodes[i] = hash;
         }
-        n = nChunks;
+        uint256 n = nChunks;
         while (n != 1) {
             for (uint256 i = 0; i < n / 2; i++) {
                 nodes[i] = keccak256(abi.encode(nodes[i * 2], nodes[i * 2 + 1]));

--- a/contracts/TestDKVDaggerHashimoto.sol
+++ b/contracts/TestDKVDaggerHashimoto.sol
@@ -24,17 +24,16 @@ contract TestDecentralizedKVDaggerHashimoto is DecentralizedKVDaggerHashimoto {
         return _preparePutWithTimestamp(currentTimestamp);
     }
 
-    function mine(
+    function mineDKV(
         uint256 startShardId,
         uint256 shardLen,
         address miner,
         uint256 minedTs,
         uint256 nonce,
-        uint256[] memory checkIdList,
         bytes32[][] memory proofsDim2,
         bytes[] memory maskedData
-    ) public override {
-        return _mine(currentTimestamp, startShardId, shardLen, miner, minedTs, nonce, checkIdList, proofsDim2, maskedData);
+    ) public {
+        return _mine(currentTimestamp, startShardId, shardLen, miner, minedTs, nonce, proofsDim2, maskedData);
     }
 
     function hashimoto(

--- a/contracts/TestDKVDaggerHashimoto.sol
+++ b/contracts/TestDKVDaggerHashimoto.sol
@@ -30,9 +30,11 @@ contract TestDecentralizedKVDaggerHashimoto is DecentralizedKVDaggerHashimoto {
         address miner,
         uint256 minedTs,
         uint256 nonce,
+        uint256[] memory checkIdList,
+        bytes32[][] memory proofsDim2,
         bytes[] memory maskedData
     ) public override {
-        return _mine(currentTimestamp, startShardId, shardLen, miner, minedTs, nonce, maskedData);
+        return _mine(currentTimestamp, startShardId, shardLen, miner, minedTs, nonce, checkIdList, proofsDim2, maskedData);
     }
 
     function hashimoto(

--- a/contracts/TestDKVDaggerHashimoto.sol
+++ b/contracts/TestDKVDaggerHashimoto.sol
@@ -24,7 +24,7 @@ contract TestDecentralizedKVDaggerHashimoto is DecentralizedKVDaggerHashimoto {
         return _preparePutWithTimestamp(currentTimestamp);
     }
 
-    function mineDKV(
+    function mine(
         uint256 startShardId,
         uint256 shardLen,
         address miner,
@@ -32,7 +32,7 @@ contract TestDecentralizedKVDaggerHashimoto is DecentralizedKVDaggerHashimoto {
         uint256 nonce,
         bytes32[][] memory proofsDim2,
         bytes[] memory maskedData
-    ) public {
+    ) public override{
         return _mine(currentTimestamp, startShardId, shardLen, miner, minedTs, nonce, proofsDim2, maskedData);
     }
 

--- a/contracts/TestDaggerHashPrecompile.sol
+++ b/contracts/TestDaggerHashPrecompile.sol
@@ -35,8 +35,9 @@ contract TestKVWithDaggerHash is TestDecentralizedKV {
     constructor(
         ISystemContractDaggerHashimoto _storageManager,
         uint256 _maxKvSize,
+        uint256 _chunkSize,
         address _daggerHashAddr
-    ) TestDecentralizedKV(_storageManager, _maxKvSize, 0, 0, 0) {
+    ) TestDecentralizedKV(_storageManager, _maxKvSize, _chunkSize, 0, 0, 0) {
         sysContract = _storageManager;
         daggerHashAddr = _daggerHashAddr;
     }

--- a/contracts/TestDaggerHashPrecompile.sol
+++ b/contracts/TestDaggerHashPrecompile.sol
@@ -11,7 +11,7 @@ contract TestDaggerHashPrecompile {
         maxKvSize = _maxKvSize;
     }
 
-    fallback (bytes calldata data) external returns (bytes memory) {
+    fallback(bytes calldata data) external returns (bytes memory) {
         require(data.length == maxKvSize + 32, "incorrect data size");
         bytes memory maskedData = data;
         bytes32 paddr;
@@ -62,7 +62,7 @@ contract TestKVWithDaggerHash is TestDecentralizedKV {
         assembly {
             paddrValue := sload(paddr.slot)
         }
-        
+
         return DaggerHashCaller.checkDaggerData(daggerHashAddr, paddrValue, maskedData);
     }
 
@@ -89,11 +89,12 @@ contract TestKVWithDaggerHash is TestDecentralizedKV {
         return sysContract.checkDaggerData(paddr.kvIdx, paddr.hash, maskedData);
     }
 
-    function checkDaggerHashNormalMerkle(uint256 idx,
-                                         bytes32 key,
-                                         bytes32[] memory proofs,
-                                         bytes memory maskedData 
-    )public view returns (bool) {
+    function checkDaggerHashNormalMerkle(
+        uint256 idx,
+        bytes32 key,
+        bytes32[] memory proofs,
+        bytes memory maskedData
+    ) public view returns (bool) {
         // Now handling data larger than 4K
         bytes32 skey = keccak256(abi.encode(msg.sender, key));
         PhyAddr memory paddr = kvMap[skey];

--- a/contracts/TestDaggerHashPrecompile.sol
+++ b/contracts/TestDaggerHashPrecompile.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.0;
 
 import "./TestDecentralizedKV.sol";
 import "./CallerLibraries.sol";
-import "hardhat/console.sol";
 
 contract TestDaggerHashPrecompile {
     uint256 immutable maxKvSize;
@@ -50,9 +49,7 @@ contract TestKVWithDaggerHash is TestDecentralizedKV {
         assembly {
             paddrValue := sload(paddr.slot)
         }
-        // This optimization is only working for we have a PhyAddr with byte32 or less length
-        // To use Merkle tree commitment, we extend a hash field from Bytes24 to Bytes32
-        // This one immediately goes invalid 
+
         return DaggerHashCaller.checkDaggerData(daggerHashAddr, paddrValue, maskedData);
     }
 
@@ -65,9 +62,7 @@ contract TestKVWithDaggerHash is TestDecentralizedKV {
         assembly {
             paddrValue := sload(paddr.slot)
         }
-        // This optimization is only working for we have a PhyAddr with byte32 or less length
-        // To use Merkle tree commitment, we extend a hash field from Bytes24 to Bytes32
-        // This one immediately goes invalid
+        
         return DaggerHashCaller.checkDaggerData(daggerHashAddr, paddrValue, maskedData);
     }
 
@@ -76,7 +71,7 @@ contract TestKVWithDaggerHash is TestDecentralizedKV {
         bytes32 skey = keccak256(abi.encode(msg.sender, key));
         PhyAddr memory paddr = kvMap[skey];
 
-        return paddr.hash == keccak256(maskedData);
+        return paddr.hash == bytes24(keccak256(maskedData));
     }
 
     function checkDaggerHashNormal(bytes32 key, bytes memory maskedData) public view returns (bool) {

--- a/contracts/TestDecentralizedKV.sol
+++ b/contracts/TestDecentralizedKV.sol
@@ -9,10 +9,11 @@ contract TestDecentralizedKV is DecentralizedKV {
     constructor(
         IStorageManager _storageManager,
         uint256 _maxKvSize,
+        uint256 _chunkSize,
         uint256 _startTime,
         uint256 _storageCost,
         uint256 _dcfFactor
-    ) DecentralizedKV(_storageManager, _maxKvSize, _startTime, _storageCost, _dcfFactor) {}
+    ) DecentralizedKV(_storageManager, _maxKvSize, _chunkSize, _startTime, _storageCost, _dcfFactor) {}
 
     function setTimestamp(uint256 ts) public {
         require(ts > currentTimestamp, "ts");

--- a/contracts/TestStorageManager.sol
+++ b/contracts/TestStorageManager.sol
@@ -16,10 +16,7 @@ contract TestStorageManager is IStorageManager {
         uint256 len
     ) external view override returns (bytes memory) {
         bytes memory data = dataMap[kvIdx];
-        uint256 n = data.length / CHUNK_SIZE;
-        uint256 nChunkBits = (n <= 1) ? 0 :
-                             BinaryRelated.getExponentiation(BinaryRelated.findNextPowerOf2(n));
-        bytes24 dataHash = bytes24(MerkleLib.merkleRoot(data, CHUNK_SIZE, nChunkBits));
+        bytes24 dataHash = bytes24(MerkleLib.merkleRootWithMinTree(data, CHUNK_SIZE));
         require(hash == dataHash, "getRaw hash mismatch");
 
         if (off >= data.length) {

--- a/contracts/TestSystemContract.sol
+++ b/contracts/TestSystemContract.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 import "./TestStorageManager.sol";
 import "./IStorageManager.sol";
+import "./MerkleLib.sol";
 
 contract TestSystemContract is TestStorageManager, ISystemContract {
     uint256 immutable maxKvSize;
@@ -42,12 +43,31 @@ contract TestSystemContract is TestStorageManager, ISystemContract {
 }
 
 contract TestSystemContractDaggerHashimoto is TestStorageManager, ISystemContractDaggerHashimoto {
+    /* NOTICE: 
+     *   This function assumes users clearly know their submitting data
+     *   is LESS OR EQUAL THAN SYSTEM_MINIMAL_BLOCK (which is 4K normally).
+     *   So basically this is a trival keccak256 comparison on a full bytes32
+     */
     function checkDaggerData(
         uint256,
         bytes32 kvHash,
         bytes memory maskedData
     ) public pure override returns (bool) {
+        bytes32[] memory proofs;
+        require(proofs.length == 0, "need an empty proofs");
+        return checkDaggerDataWithProof(0, kvHash, proofs, maskedData);
+    }
+
+    function checkDaggerDataWithProof(
+        uint256 idx,
+        bytes32 kvHash,
+        bytes32[] memory proofs,
+        bytes memory maskedData
+    ) public pure override returns (bool) {
         bytes32 dataHash = keccak256(maskedData);
-        return bytes24(dataHash) == bytes24(kvHash);
+        return MerkleLib.verify(dataHash,
+                                idx, /* Slice Id */
+                                kvHash, /*Merkle Tree Root*/
+                                proofs);
     }
 }

--- a/contracts/TestSystemContract.sol
+++ b/contracts/TestSystemContract.sol
@@ -65,9 +65,13 @@ contract TestSystemContractDaggerHashimoto is TestStorageManager, ISystemContrac
         bytes memory maskedData
     ) public pure override returns (bool) {
         bytes32 dataHash = keccak256(maskedData);
-        return MerkleLib.verify(dataHash,
-                                idx, /* Slice Id */
-                                kvHash, /*Merkle Tree Root*/
-                                proofs);
+        bytes32 rootFromProofs = MerkleLib.calculateRootWithProof(dataHash, idx, proofs);
+        /* NOTICE: Due to our design of PhyAddr, only front 24 bytes
+         *         are valid. We only validate that part.
+         * With no doubt, it introduces some vulnerability compared 
+         * with a standard Merkle validation. It is a trade-off,
+         * if we want to put all meta data into a single bytes32(opcode length)
+         */
+        return bytes24(rootFromProofs) == bytes24(kvHash);
     }
 }

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -64,7 +64,7 @@ module.exports = {
     grep: process.env.MOCHA_GREP || "",
   },
   solidity: {
-    version: "0.8.0",
+    version: "0.8.16",
     settings: {
       optimizer: {
         enabled: true,

--- a/test/dagger-hash-precompile-test.js
+++ b/test/dagger-hash-precompile-test.js
@@ -23,9 +23,8 @@ describe("DaggerHash Test", function () {
       "0x11223344"
     );
 
-    // TODO: Not apply for current PhysAddr extending 32 bytes
-    //expect(await kv.checkDaggerHash(testKey, "0x11223344"))
-    //  .to.be.true;
+    expect(await kv.checkDaggerHash(testKey, "0x11223344"))
+      .to.be.true;
     
     expect(
       await kv.checkDaggerHashNormal(testKey, "0x11223344")
@@ -51,9 +50,8 @@ describe("DaggerHash Test", function () {
     await kv.put(testKey, d);
     expect(await kv.get(testKey, 0, 4096)).to.equal(d);
 
-    // TODO: Not apply for current PhysAddr extending 32 bytes
-    //expect(await kv.checkDaggerHash(testKey, d)).to.be
-    //  .true;
+    expect(await kv.checkDaggerHash(testKey, d)).to.be
+      .true;
 
     expect(await kv.checkDaggerHashNormal(testKey, d)).to
       .be.true;
@@ -83,9 +81,6 @@ describe("DaggerHash Test", function () {
     await kv.put(testKey, d);
     expect(await kv.get(testKey, 0, 8192)).to.equal(d);
 
-    // TODO: Not apply for current PhysAddr extending 32 bytes
-    //expect(await kv.checkDaggerHash(testKey, d)).to.be
-    //  .true;
     const root = await ml.merkleRoot(data, 4096, 1);
     const leftSliceProof = await ml.getProof(data,4096,1,0);
     const rightSliceProof = await ml.getProof(data,4096,1,1);
@@ -95,7 +90,7 @@ describe("DaggerHash Test", function () {
     // Via sysContract's method
     expect(await kv.checkDaggerHashNormalMerkle(0, testKey, leftSliceProof, data.slice(0,4096))).to
       .be.true;
-    expect(await kv.checkDaggerHashNormalMerkle(0, testKey, leftSliceProof, data.slice(0,4096))).to
+    expect(await kv.checkDaggerHashNormalMerkle(1, testKey, rightSliceProof, data.slice(4096,4096*2))).to
       .be.true;
   });
 });

--- a/test/dagger-hash-precompile-test.js
+++ b/test/dagger-hash-precompile-test.js
@@ -15,7 +15,7 @@ describe("DaggerHash Test", function () {
     const dg = await TestDaggerHashPrecompile.deploy(4);
     await dg.deployed();
     const DecentralizedKV = await ethers.getContractFactory("TestKVWithDaggerHash");
-    const kv = await DecentralizedKV.deploy(sm.address, 4, dg.address);
+    const kv = await DecentralizedKV.deploy(sm.address, 4, 4, dg.address);
     await kv.deployed();
 
     await kv.put(testKey, "0x11223344");
@@ -39,7 +39,7 @@ describe("DaggerHash Test", function () {
     const dg = await TestDaggerHashPrecompile.deploy(4096);
     await dg.deployed();
     const DecentralizedKV = await ethers.getContractFactory("TestKVWithDaggerHash");
-    const kv = await DecentralizedKV.deploy(sm.address, 4096, dg.address);
+    const kv = await DecentralizedKV.deploy(sm.address, 4096, 4096, dg.address);
     await kv.deployed();
 
     let d = "0x";
@@ -70,7 +70,7 @@ describe("DaggerHash Test", function () {
     const dg = await TestDaggerHashPrecompile.deploy(8192);
     await dg.deployed();
     const DecentralizedKV = await ethers.getContractFactory("TestKVWithDaggerHash");
-    const kv = await DecentralizedKV.deploy(sm.address, 8192, dg.address);
+    const kv = await DecentralizedKV.deploy(sm.address, 8192, 4096, dg.address);
     await kv.deployed();
     const MerkleLib = await ethers.getContractFactory("TestMerkleLib");
     const ml = await MerkleLib.deploy();

--- a/test/dagger-hash-precompile-test.js
+++ b/test/dagger-hash-precompile-test.js
@@ -1,10 +1,11 @@
 const { web3 } = require("hardhat");
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
+const crypto = require("crypto");
 
 var ToBig = (x) => ethers.BigNumber.from(x);
 var hexlify4 = (x) => ethers.utils.hexZeroPad(ethers.utils.hexlify(x), 4);
-
+const testKey = "0x0000000000000000000000000000000000000000000000000000000000000001"
 describe("DaggerHash Test", function () {
   it("small-value", async function () {
     const StorageManager = await ethers.getContractFactory("TestSystemContractDaggerHashimoto");
@@ -17,15 +18,17 @@ describe("DaggerHash Test", function () {
     const kv = await DecentralizedKV.deploy(sm.address, 4, dg.address);
     await kv.deployed();
 
-    await kv.put("0x0000000000000000000000000000000000000000000000000000000000000001", "0x11223344");
-    expect(await kv.get("0x0000000000000000000000000000000000000000000000000000000000000001", 0, 4)).to.equal(
+    await kv.put(testKey, "0x11223344");
+    expect(await kv.get(testKey, 0, 4)).to.equal(
       "0x11223344"
     );
 
-    expect(await kv.checkDaggerHash("0x0000000000000000000000000000000000000000000000000000000000000001", "0x11223344"))
-      .to.be.true;
+    // TODO: Not apply for current PhysAddr extending 32 bytes
+    //expect(await kv.checkDaggerHash(testKey, "0x11223344"))
+    //  .to.be.true;
+    
     expect(
-      await kv.checkDaggerHashNormal("0x0000000000000000000000000000000000000000000000000000000000000001", "0x11223344")
+      await kv.checkDaggerHashNormal(testKey, "0x11223344")
     ).to.be.true;
   });
 
@@ -45,18 +48,20 @@ describe("DaggerHash Test", function () {
       d = ethers.utils.hexConcat([d, ethers.utils.keccak256(hexlify4(j))]);
     }
 
-    await kv.put("0x0000000000000000000000000000000000000000000000000000000000000001", d);
-    expect(await kv.get("0x0000000000000000000000000000000000000000000000000000000000000001", 0, 4096)).to.equal(d);
+    await kv.put(testKey, d);
+    expect(await kv.get(testKey, 0, 4096)).to.equal(d);
 
-    expect(await kv.checkDaggerHash("0x0000000000000000000000000000000000000000000000000000000000000001", d)).to.be
-      .true;
-    expect(await kv.checkDaggerHashNormal("0x0000000000000000000000000000000000000000000000000000000000000001", d)).to
+    // TODO: Not apply for current PhysAddr extending 32 bytes
+    //expect(await kv.checkDaggerHash(testKey, d)).to.be
+    //  .true;
+
+    expect(await kv.checkDaggerHashNormal(testKey, d)).to
       .be.true;
 
     // Uncomment for gas report
-    await kv.checkDaggerHashNonView("0x0000000000000000000000000000000000000000000000000000000000000001", d);
-    await kv.checkDaggerHashDirectNonView("0x0000000000000000000000000000000000000000000000000000000000000001", d);
-    await kv.checkDaggerHashNormalNonView("0x0000000000000000000000000000000000000000000000000000000000000001", d);
+    await kv.checkDaggerHashNonView(testKey, d);
+    await kv.checkDaggerHashDirectNonView(testKey, d);
+    await kv.checkDaggerHashNormalNonView(testKey, d);
   });
 
   it("8KB-value", async function () {
@@ -69,24 +74,28 @@ describe("DaggerHash Test", function () {
     const DecentralizedKV = await ethers.getContractFactory("TestKVWithDaggerHash");
     const kv = await DecentralizedKV.deploy(sm.address, 8192, dg.address);
     await kv.deployed();
+    const MerkleLib = await ethers.getContractFactory("TestMerkleLib");
+    const ml = await MerkleLib.deploy();
+    await ml.deployed();
 
-    let d = "0x";
-    let d32 = ethers.utils.keccak256(hexlify4(0));
-    for (let j = 0; j < 8192 / 32; j++) {
-      d = ethers.utils.hexConcat([d, d32]);
-    }
+    const data = crypto.randomBytes(4096 * 2)
+    const d = ethers.utils.hexlify(data);
+    await kv.put(testKey, d);
+    expect(await kv.get(testKey, 0, 8192)).to.equal(d);
 
-    await kv.put("0x0000000000000000000000000000000000000000000000000000000000000001", d);
-    expect(await kv.get("0x0000000000000000000000000000000000000000000000000000000000000001", 0, 8192)).to.equal(d);
-
-    expect(await kv.checkDaggerHash("0x0000000000000000000000000000000000000000000000000000000000000001", d)).to.be
-      .true;
-    expect(await kv.checkDaggerHashNormal("0x0000000000000000000000000000000000000000000000000000000000000001", d)).to
+    // TODO: Not apply for current PhysAddr extending 32 bytes
+    //expect(await kv.checkDaggerHash(testKey, d)).to.be
+    //  .true;
+    const root = await ml.merkleRoot(data, 4096, 1);
+    const leftSliceProof = await ml.getProof(data,4096,1,0);
+    const rightSliceProof = await ml.getProof(data,4096,1,1);
+    // A direct merkle tree verify
+    expect(await ml.verify(data.slice(0,4096), 0, root, leftSliceProof)).to.be.true;
+    expect(await ml.verify(data.slice(4096,8192), 1, root, rightSliceProof)).to.be.true;
+    // Via sysContract's method
+    expect(await kv.checkDaggerHashNormalMerkle(0, testKey, leftSliceProof, data.slice(0,4096))).to
       .be.true;
-
-    // Uncomment for gas report
-    await kv.checkDaggerHashNonView("0x0000000000000000000000000000000000000000000000000000000000000001", d);
-    await kv.checkDaggerHashDirectNonView("0x0000000000000000000000000000000000000000000000000000000000000001", d);
-    await kv.checkDaggerHashNormalNonView("0x0000000000000000000000000000000000000000000000000000000000000001", d);
+    expect(await kv.checkDaggerHashNormalMerkle(0, testKey, leftSliceProof, data.slice(0,4096))).to
+      .be.true;
   });
 });

--- a/test/decentralized-kv-test.js
+++ b/test/decentralized-kv-test.js
@@ -13,7 +13,7 @@ describe("DecentralizedKV Test", function () {
     const sm = await StorageManager.deploy();
     await sm.deployed();
     const DecentralizedKV = await ethers.getContractFactory("TestDecentralizedKV");
-    const kv = await DecentralizedKV.deploy(sm.address, 1024, 0, 0, 0);
+    const kv = await DecentralizedKV.deploy(sm.address, 1024, 1024, 0, 0, 0);
     await kv.deployed();
 
     await kv.put(key1, "0x11223344");
@@ -33,7 +33,7 @@ describe("DecentralizedKV Test", function () {
     const sm = await StorageManager.deploy();
     await sm.deployed();
     const DecentralizedKV = await ethers.getContractFactory("TestDecentralizedKV");
-    const kv = await DecentralizedKV.deploy(sm.address, 1024, 0, 0, 0);
+    const kv = await DecentralizedKV.deploy(sm.address, 1024, 1024, 0, 0, 0);
     await kv.deployed();
 
     await kv.put(key1, "0x11223344");
@@ -67,6 +67,7 @@ describe("DecentralizedKV Test", function () {
     // 1e18 cost with 0.5 discount rate per second
     const kv = await DecentralizedKV.deploy(
       sm.address,
+      1024,
       1024,
       0,
       "1000000000000000000",
@@ -114,6 +115,7 @@ describe("DecentralizedKV Test", function () {
     const kv = await DecentralizedKV.deploy(
       sm.address,
       1024,
+      1024,
       0,
       "1000000000000000000",
       "340282365784068676928457747575078800565"
@@ -147,7 +149,7 @@ describe("DecentralizedKV Test", function () {
     await sm.deployed();
     const DecentralizedKV = await ethers.getContractFactory("TestDecentralizedKV");
     // 1e18 cost with 0.5 discount rate per second
-    const kv = await DecentralizedKV.deploy(sm.address, 1024, 0, 0, 0);
+    const kv = await DecentralizedKV.deploy(sm.address, 1024, 1024, 0, 0, 0);
     await kv.deployed();
 
     // write random data

--- a/test/dkv-dagger-hashimoto-test.js
+++ b/test/dkv-dagger-hashimoto-test.js
@@ -285,7 +285,7 @@ describe("Full cycle of mining procedure", function () {
     return numbers.slice(0,randomChecks);
   }
 
-  it("runs full mining cycle", async function () {
+  it("runs full mining cycle small", async function () {
     const [owner, addr1, addr2] = await ethers.getSigners();
     let wallet = ethers.Wallet.createRandom().connect(owner.provider);
     const SystemContract = await ethers.getContractFactory("TestSystemContractDaggerHashimoto");
@@ -368,7 +368,7 @@ describe("Full cycle of mining procedure", function () {
     }
     expect(LIMIT).to.be.above(count);
 
-    await kv.mine(0,0,wallet.address,mineTs,nonce,maskedData);
+    await kv.mine(0,0,wallet.address,mineTs,nonce,[0],[[]],maskedData);
     
   });
 });

--- a/test/dkv-dagger-hashimoto-test.js
+++ b/test/dkv-dagger-hashimoto-test.js
@@ -23,7 +23,7 @@ describe("Basic Func Test", function () {
     const MinabledKV = await ethers.getContractFactory("TestDecentralizedKVDaggerHashimoto");
     // 64 bytes per data, 4 entries in shard, 1 random access
     const kv = await MinabledKV.deploy(
-      [6, 8, 1, 0, 60, 40, 1024, 0, sc.address],
+      [6, 6, 8, 1, 0, 60, 40, 1024, 0, sc.address],
       0,
       0,
       0,
@@ -53,7 +53,7 @@ describe("Basic Func Test", function () {
     const MinabledKV = await ethers.getContractFactory("TestDecentralizedKVDaggerHashimoto");
     // 64 bytes per data, 4 entries in shard, 2 random access
     const kv = await MinabledKV.deploy(
-      [6, 8, 2, 0, 60, 40, 1024, 0, sc.address],
+      [6, 6, 8, 2, 0, 60, 40, 1024, 0, sc.address],
       0,
       0,
       0,
@@ -86,7 +86,7 @@ describe("Basic Func Test", function () {
     const MinabledKV = await ethers.getContractFactory("TestDecentralizedKVDaggerHashimoto");
     // 4096 bytes per data, 32 entries in shard, 16 random access
     const kv = await MinabledKV.deploy(
-      [12, 17, 16, 0, 60, 40, 1024, 0, sc.address],
+      [12, 12, 17, 16, 0, 60, 40, 1024, 0, sc.address],
       0,
       0,
       0,
@@ -154,7 +154,7 @@ describe("Basic Func Test", function () {
     const MinabledKV = await ethers.getContractFactory("TestDecentralizedKVDaggerHashimoto");
     // 4096 bytes per data, 32 entries in shard, 16 random access
     const kv = await MinabledKV.deploy(
-      [12, 17, 3, 0, 60, 40, 1024, 0, sc.address],
+      [12, 12, 17, 3, 0, 60, 40, 1024, 0, sc.address],
       0,
       0,
       0,
@@ -201,7 +201,7 @@ describe("Basic Func Test", function () {
     const sc = await SystemContract.deploy();
     await sc.deployed();
     const MinabledKV = await ethers.getContractFactory("TestDecentralizedKVDaggerHashimoto");
-    const kv = await MinabledKV.deploy([5, 8, 6, 10, 60, 40, 1024, 0, sc.address], 0, 0, 0, formatB32Str("genesis"));
+    const kv = await MinabledKV.deploy([5, 5, 8, 6, 10, 60, 40, 1024, 0, sc.address], 0, 0, 0, formatB32Str("genesis"));
     await kv.deployed();
 
     let m0 = await kv.calculateDiffAndInitHash(0, 1, 5);
@@ -220,6 +220,7 @@ describe("Basic Func Test", function () {
 
 describe("Full cycle of mining procedure", function () {
   const maxKvSizeBits = 6;
+  const chunkSizeBits = 6;
   const shardSizeBits = 10;
   const randomChecks = 1;
   const minimumDiff = 1;
@@ -295,7 +296,7 @@ describe("Full cycle of mining procedure", function () {
     const MinabledKV = await ethers.getContractFactory("TestDecentralizedKVDaggerHashimoto");
     // 64 bytes per data, 16 entries in shard, 4 random access
     const kv = await MinabledKV.deploy(
-      [maxKvSizeBits, shardSizeBits, randomChecks, minimumDiff, 
+      [maxKvSizeBits, chunkSizeBits, shardSizeBits, randomChecks, minimumDiff, 
        targetIntervalSec, cutoff, diffAdjDivisor, coinbaseShare, sc.address],
       0, //startTime
       0, //storageCost
@@ -369,13 +370,14 @@ describe("Full cycle of mining procedure", function () {
     }
     expect(LIMIT).to.be.above(count);
 
-    await kv.mineDKV(0,0,wallet.address,mineTs,nonce,[[]],maskedData);
+    await kv.mine(0,0,wallet.address,mineTs,nonce,[[]],maskedData);
     
   });
 });
 
 describe("Full cycle of mining procedure with Merkle proof", function () {
   const maxKvSizeBits = 13; // 4K x 2
+  const chunkSizeBits = 12; // 4K
   const shardSizeBits = 14; // 2 blocks per shard
   const randomChecks = 1;
   const minimumDiff = 1;
@@ -430,7 +432,7 @@ describe("Full cycle of mining procedure with Merkle proof", function () {
     const MinabledKV = await ethers.getContractFactory("TestDecentralizedKVDaggerHashimoto");
     // 32KB per KV block, 4 entries in shard, 1 random access
     const kv = await MinabledKV.deploy(
-      [maxKvSizeBits, shardSizeBits, randomChecks, minimumDiff, 
+      [maxKvSizeBits, chunkSizeBits, shardSizeBits, randomChecks, minimumDiff, 
        targetIntervalSec, cutoff, diffAdjDivisor, coinbaseShare, sc.address],
       0, //startTime
       0, //storageCost
@@ -514,10 +516,10 @@ describe("Full cycle of mining procedure with Merkle proof", function () {
       const data = dataList[randomList[i]];
       const chunkIdx = chunkIdArray[i];
       const proof = await ml.getProof(data, CHUNK_SIZE, chunkLenBits, chunkIdx);
-      proofsDim2.push(proof)
+      proofsDim2.push(proof);
     }
 
-    await kv.mineDKV(0,0,wallet.address,mineTs,nonce,proofsDim2,maskedData);
+    await kv.mine(0,0,wallet.address,mineTs,nonce,proofsDim2,maskedData);
     
   });
 });

--- a/test/dkv-dagger-hashimoto-test.js
+++ b/test/dkv-dagger-hashimoto-test.js
@@ -1,6 +1,7 @@
 const { web3 } = require("hardhat");
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
+const { crypto } = require("crypto");
 
 var ToBig = (x) => ethers.BigNumber.from(x);
 var padRight32 = (x) => x.padEnd(66, "0");
@@ -368,7 +369,7 @@ describe("Full cycle of mining procedure", function () {
     }
     expect(LIMIT).to.be.above(count);
 
-    await kv.mine(0,0,wallet.address,mineTs,nonce,[0],[[]],maskedData);
+    await kv.mineDKV(0,0,wallet.address,mineTs,nonce,[[]],maskedData);
     
   });
 });

--- a/test/merkle-test.js
+++ b/test/merkle-test.js
@@ -3,6 +3,7 @@ const { expect } = require("chai");
 const { ethers } = require("hardhat");
 const crypto = require("crypto");
 
+var hexlify4 = (x) => ethers.utils.hexZeroPad(ethers.utils.hexlify(x), 4);
 describe("MerkleLib Test", function () {
   it("full zero data verify", async function () {
     const MerkleLib = await ethers.getContractFactory("TestMerkleLib");
@@ -30,6 +31,20 @@ describe("MerkleLib Test", function () {
       let chunkData = data.slice(i * 64, (i + 1) * 64);
       expect(await ml.verify(chunkData, i, root, proof)).to.equal(true);
     }
+  });
+
+  it("8K data testing", async function () {
+    // 4K as chunk
+    const MerkleLib = await ethers.getContractFactory("TestMerkleLib");
+    const ml = await MerkleLib.deploy();
+    await ml.deployed();
+
+    const d = crypto.randomBytes(4096 * 2);
+    const root = await ml.merkleRoot(d, 4096, 1);
+    const leftSliceProof = await ml.getProof(d,4096,1,0);
+    expect(await ml.verify(d.slice(0,4096), 0, root, leftSliceProof)).to.be.true;
+    const rightSliceProof = await ml.getProof(d,4096,1,1);
+    expect(await ml.verify(d.slice(4096,8192), 1, root, rightSliceProof)).to.be.true;
   });
 
   it("partial random data verify0", async function () {

--- a/test/merkle-test.js
+++ b/test/merkle-test.js
@@ -125,7 +125,7 @@ describe("MerkleLib Test", function () {
     let proof = await ml.getProof(data, 64, 3, 0);
     expect(await ml.verify(data.slice(0,64), 0, root, proof)).to.equal(true);
     // out of bound index
-    expect(await ml.verify(data.slice(0,64), 8, root, proof)).to.equal(false);
-    expect(await ml.verify(data.slice(0,64), 10, root, proof)).to.equal(false);
+    await expect(ml.verify(data.slice(0,64), 8, root, proof)).to.be.revertedWith("chunkId overflows");
+    await expect(ml.verify(data.slice(0,64), 10, root, proof)).to.be.revertedWith("chunkId overflows");
   });
 });

--- a/test/mining-test.js
+++ b/test/mining-test.js
@@ -15,7 +15,7 @@ describe("Basic Func Test", function () {
     await sc.deployed();
     const MinabledKV = await ethers.getContractFactory("TestDecentralizedKVMinable");
     const kv = await MinabledKV.deploy(
-      [5, 8, 6, 0, 60, 40, 1024, 0, sc.address],
+      [5, 5, 8, 6, 0, 60, 40, 1024, 0, sc.address],
       0,
       0,
       0,
@@ -52,7 +52,7 @@ describe("Basic Func Test", function () {
     await sc.deployed();
     const MinabledKV = await ethers.getContractFactory("TestDecentralizedKVMinable");
     const kv = await MinabledKV.deploy(
-      [12, 31, 20, 0, 60, 40, 1024, 0, sc.address],
+      [12, 12, 31, 20, 0, 60, 40, 1024, 0, sc.address],
       0,
       0,
       0,
@@ -79,7 +79,7 @@ describe("Basic Func Test", function () {
     await sc.deployed();
     const MinabledKV = await ethers.getContractFactory("TestDecentralizedKVMinable");
     const kv = await MinabledKV.deploy(
-      [5, 8, 6, 0, 60, 40, 1024, 0, sc.address],
+      [5, 5, 8, 6, 0, 60, 40, 1024, 0, sc.address],
       0,
       0,
       0,
@@ -133,7 +133,7 @@ describe("Basic Func Test", function () {
     const sc = await SystemContract.deploy(32);
     await sc.deployed();
     const MinabledKV = await ethers.getContractFactory("TestDecentralizedKVMinable");
-    const kv = await MinabledKV.deploy([5, 8, 6, 10, 60, 40, 1024, 0, sc.address], 0, 0, 0, formatB32Str("genesis"));
+    const kv = await MinabledKV.deploy([5, 5, 8, 6, 10, 60, 40, 1024, 0, sc.address], 0, 0, 0, formatB32Str("genesis"));
     await kv.deployed();
 
     let m0 = await kv.calculateDiffAndInitHash(0, 1, 5);
@@ -160,7 +160,7 @@ describe("rewardMiner", function () {
     await sc.deployed();
     const MinabledKV = await ethers.getContractFactory("TestDecentralizedKVMinable");
     const kv = await MinabledKV.deploy(
-      [5, 8, 6, 10, 60, 40, 1024, 0, sc.address],
+      [5, 5, 8, 6, 10, 60, 40, 1024, 0, sc.address],
       5,
       "1000000000000000000", // for all
       "170141183460469231731687303715884105728", // 0.5
@@ -193,7 +193,7 @@ describe("rewardMiner", function () {
     await sc.deployed();
     const MinabledKV = await ethers.getContractFactory("TestDecentralizedKVMinable");
     const kv = await MinabledKV.deploy(
-      [5, 8, 6, 10, 60, 40, 1024, 0, sc.address],
+      [5, 5, 8, 6, 10, 60, 40, 1024, 0, sc.address],
       5,
       "1000000000000000000", // for all
       "170141183460469231731687303715884105728", // 0.5
@@ -263,7 +263,7 @@ describe("rewardMiner", function () {
     await sc.deployed();
     const MinabledKV = await ethers.getContractFactory("TestDecentralizedKVMinable");
     const kv = await MinabledKV.deploy(
-      [5, 8, 6, 10, 60, 40, 1024, 0, sc.address],
+      [5, 5, 8, 6, 10, 60, 40, 1024, 0, sc.address],
       5,
       "1000000000000000000", // for all
       "170141183460469231731687303715884105728", // 0.5
@@ -296,7 +296,7 @@ describe("rewardMiner", function () {
     await sc.deployed();
     const MinabledKV = await ethers.getContractFactory("TestDecentralizedKVMinable");
     const kv = await MinabledKV.deploy(
-      [5, 8, 6, 10, 60, 40, 1024, 0, sc.address],
+      [5, 5, 8, 6, 10, 60, 40, 1024, 0, sc.address],
       100,
       "1000000000000000000", // for all
       "340282365784068676928457747575078800565", // 0.5


### PR DESCRIPTION
Motivation:
The DecentralizedKV is divided by term MaxKvValue. User uses put semantics to put a trunk data in someone's disk, whose size is exactly MaxKvValue. Nowadays, the value is 4K, for current SSD minimal fetching unit is 4KB. However, Danksharding proposal supports a 128KB per BLOB.

For first time put, we cannot aviod to upload full data to generate a hash commiment. But we can reduce gas on submitting RoRA (via Dagger-Hashimoto) proof, by changing a full-data hash commitment to somewhat inclusion proof, and yes, Merkle tree can be an ideal tool.

By this changing, each time miner being asked to submit PoRA, it can just choose 4KB pieces of whole data, and then generate Merkle proof, thus submitting proofs, id it chooses and 4KB piece of data. On chain, KV contract does an Merkle inclusion verification. The effect is identical as previous one, in term of demand of Proof of Random Access.

Change:
KV contract, extends bytes24 hash to a bytes32 standard hash after keccak256 TestSystemContract, change both verify functions
Add tests about submitting proofs + verifying